### PR TITLE
Enable teardown

### DIFF
--- a/tests/base-test.js
+++ b/tests/base-test.js
@@ -8,7 +8,7 @@ module.exports.all = function (test, common) {
       pr.findPeers(Id.create().toBytes(), function (err, peerQueue) {
         t.ifError(err)
         t.equal(peerQueue.length >= 1, true)
-        // common.teardown()
+        common.teardown()
       })
     })
   })


### PR DESCRIPTION
This is not allowing some tests to clean their listeners.

Related: https://github.com/diasdavid/node-libp2p-kad-routing/issues/2
