### PR TITLE
Adds `addPeer`

### DIFF
--- a/tests/base-test.js
+++ b/tests/base-test.js
@@ -2,13 +2,22 @@ var Id = require('peer-id')
 
 module.exports.all = function (test, common) {
   test('Simple findPeers test', function (t) {
-    common.setup(test, function (err, pr) {
-      t.plan(3)
+    t.plan(4)
+    common.createPeer(function (err, pr1) {
       t.ifError(err)
-      pr.findPeers(Id.create().toBytes(), function (err, peerQueue) {
+      common.createPeer(function (err, pr2) {
         t.ifError(err)
-        t.equal(peerQueue.length >= 1, true)
-        common.teardown()
+
+        pr1.addPeer(pr2)
+        pr2.addPeer(pr1)
+
+        pr1.findPeers(Id.create().toBytes(), function (err, peerQueue) {
+          t.ifError(err)
+
+          t.equal(peerQueue.length, 1, 'should have one peer')
+          common.teardown(pr1)
+          common.teardown(pr2)
+        })
       })
     })
   })

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,6 +1,6 @@
 var timed = require('timed-tape')
 
 module.exports = function (test, common) {
-  test = timed(test)
+  // test = timed(test)
   require('./base-test.js').all(test, common)
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,6 +1,6 @@
 var timed = require('timed-tape')
 
 module.exports = function (test, common) {
-  // test = timed(test)
+  test = timed(test)
   require('./base-test.js').all(test, common)
 }


### PR DESCRIPTION
This PR Adds `addPeer` and changes setup to `createPeer` which is expected to give back a peer each time it is called. Also teardown now is given a peer which is then stoped or closed.
