### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The API is presented with both Node.js and Go primitives, however, there is not 
 
 # Modules that implement the interface
 
-- https://github.com/diasdavid/node-ipfs-kad-router
+- https://github.com/libp2p/js-libp2p-kad-routing
 
 # Badge
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein
### GitHub Corrected URLs

| Was | Now |
| --- | --- |
| https://github.com/diasdavid/node-ipfs-kad-router | https://github.com/libp2p/js-libp2p-kad-routing |
