### PR TITLE
docs: add lead-maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Publishing a test suite as a module lets multiple modules all ensure compatibili
 
 The API is presented with both Node.js and Go primitives, however, there is not actual limitations for it to be extended for any other language, pushing forward the cross compatibility and interop through diferent stacks.
 
+## Lead Maintainer
+
+[Vasco Santos](https://github.com/vasco-santos).
+
 # Modules that implement the interface
 
 - [JavaScript libp2p-kad-dht](https://github.com/libp2p/js-libp2p-kad-dht)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "interface-peer-routing",
   "version": "0.1.3",
   "description": "A test suite and interface you can use to implement a Peer Routing for libp2p.",
+  "leadMaintainer": "Vasco Santos <vasco.santos@moxy.studio>",
   "repository": {
     "type": "git",
     "url": "https://github.com/diasdavid/interface-peer-routing.git"


### PR DESCRIPTION
In the context of https://github.com/ipfs/pm/issues/600, [js-libp2p#259](https://github.com/libp2p/js-libp2p/issues/259) and [js-libp2p/pull/265](https://github.com/libp2p/js-libp2p/pull/265).

Needs:

- [x] Update each package.json and README.md to have a leadMaintainer field.
- [x] Update [packages table](https://github.com/libp2p/js-libp2p/blob/3226632d83e8684e32b00eeb398b21158b94586d/README.md#packages) - [js-libp2p#265](https://github.com/libp2p/js-libp2p/pull/265)
- [x] Grant publish permission to the Maintainer